### PR TITLE
fixed initialization of journal and snapshot-store from HOCON config

### DIFF
--- a/Akka.Persistence.Pulsar.Tests/PulsarSnapshotStoreSpec.cs
+++ b/Akka.Persistence.Pulsar.Tests/PulsarSnapshotStoreSpec.cs
@@ -1,0 +1,20 @@
+using Akka.Configuration;
+using Akka.Persistence.Pulsar.Snapshot;
+using Akka.Persistence.TCK.Snapshot;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Pulsar.Tests
+{
+    public class PulsarSnapshotStoreSpec : SnapshotStoreSpec
+    {
+        public static Config SpecConfig = ConfigurationFactory.ParseString(@"
+            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.pulsar""
+            akka.test.single-expect-default = 10s
+        ").WithFallback(PulsarPersistence.DefaultConfiguration());
+        
+        public PulsarSnapshotStoreSpec(ITestOutputHelper output) : base(SpecConfig , output: output)
+        {
+            Initialize();
+        }
+    }
+}

--- a/Akka.Persistence.Pulsar/Journal/PulsarJournal.cs
+++ b/Akka.Persistence.Pulsar/Journal/PulsarJournal.cs
@@ -19,6 +19,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Configuration;
 using Akka.Event;
 using Akka.Persistence.Journal;
 using Akka.Persistence.Pulsar.Query;
@@ -57,7 +58,7 @@ namespace Akka.Persistence.Pulsar.Journal
 
         //public Akka.Serialization.Serialization Serialization => _serialization ??= Context.System.Serialization;
 
-        public PulsarJournal() : this(PulsarPersistence.Get(Context.System).JournalSettings)
+        public PulsarJournal(Config config) : this(new PulsarSettings(config))
         {
 
         }

--- a/Akka.Persistence.Pulsar/PulsarPersistence.cs
+++ b/Akka.Persistence.Pulsar/PulsarPersistence.cs
@@ -9,6 +9,8 @@
 
 
 using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Pulsar.Query;
 
 namespace Akka.Persistence.Pulsar
 {
@@ -16,12 +18,19 @@ namespace Akka.Persistence.Pulsar
     public sealed class PulsarPersistence : IExtension
     {
         private readonly ExtendedActorSystem _system;
-        public PulsarSettings JournalSettings { get; }
-
-        public PulsarPersistence(ExtendedActorSystem system, PulsarSettings journalSettings)
+        
+        /// <summary>
+        /// Returns a default query configuration for akka persistence SQLite-based journals and snapshot stores.
+        /// </summary>
+        /// <returns></returns>
+        public static Config DefaultConfiguration()
+        {
+            return ConfigurationFactory.FromResource<PulsarReadJournal>("Akka.Persistence.Pulsar.reference.conf");
+        }
+        
+        public PulsarPersistence(ExtendedActorSystem system)
         {
             _system = system;
-            JournalSettings = journalSettings;
         }
 
         public static PulsarPersistence Get(ActorSystem system) => 
@@ -32,8 +41,7 @@ namespace Akka.Persistence.Pulsar
     {
         public override PulsarPersistence CreateExtension(ExtendedActorSystem system)
         {
-            var journalSettings = new PulsarSettings(system.Settings.Config.GetConfig("akka.persistence.journal.pulsar"));
-            return new PulsarPersistence(system, journalSettings);
+            return new PulsarPersistence(system);
         }
     }
 }

--- a/Akka.Persistence.Pulsar/PulsarSettings.cs
+++ b/Akka.Persistence.Pulsar/PulsarSettings.cs
@@ -20,6 +20,11 @@ namespace Akka.Persistence.Pulsar
     {
         public PulsarSettings(Config config)
         {
+            if (config is null)
+            {
+                throw new ArgumentNullException(nameof(config), "Pulsar settings HOCON configuration is missing");
+            }
+            
             ServiceUrl = config.GetString("service-url", "pulsar://localhost:6650");
             VerifyCertificateAuthority = config.GetBoolean("verify-certificate-authority", true);
             VerifyCertificateName = config.GetBoolean("verify-cerfiticate-name", false);

--- a/Akka.Persistence.Pulsar/Query/PulsarReadJournal.cs
+++ b/Akka.Persistence.Pulsar/Query/PulsarReadJournal.cs
@@ -41,15 +41,6 @@ namespace Akka.Persistence.Pulsar.Query
         }
 
         /// <summary>
-        /// Returns a default query configuration for akka persistence SQLite-based journals and snapshot stores.
-        /// </summary>
-        /// <returns></returns>
-        public static Config DefaultConfiguration()
-        {
-            return ConfigurationFactory.FromResource<PulsarReadJournal>("Akka.Persistence.Pulsar.reference.conf");
-        }
-
-        /// <summary>
         /// <para>
         /// <see cref="PersistenceIds"/> is used for retrieving all `persistenceIds` of all
         /// persistent actors.

--- a/Akka.Persistence.Pulsar/Snapshot/PulsarSnapshotStore.cs
+++ b/Akka.Persistence.Pulsar/Snapshot/PulsarSnapshotStore.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Configuration;
 using Akka.Util;
 using SharpPulsar.Akka;
 using SharpPulsar.Akka.Configuration;
@@ -40,7 +41,7 @@ namespace Akka.Persistence.Pulsar.Snapshot
 
         //public Akka.Serialization.Serialization Serialization => _serialization ??= Context.System.Serialization;
 
-        public PulsarSnapshotStore() : this(PulsarPersistence.Get(Context.System).JournalSettings)
+        public PulsarSnapshotStore(Config config) : this(new PulsarSettings(config))
         {
 
         }

--- a/Akka.Persistence.Pulsar/reference.conf
+++ b/Akka.Persistence.Pulsar/reference.conf
@@ -14,16 +14,26 @@ akka.persistence.journal.pulsar {
   # Verify certificate name with hostname.
   verify-cerfiticate-name = false  
 }
+
 akka.persistence.snapshot-store.pulsar {
-		# qualified type name of the MongoDB persistence snapshot actor
-			class = "Akka.Persistence.Pulsar.Snapshot.PulsarSnapshotStore, Akka.Persistence.Pulsar"
+  # qualified type name of the MongoDB persistence snapshot actor
+  class = "Akka.Persistence.Pulsar.Snapshot.PulsarSnapshotStore, Akka.Persistence.Pulsar"
 
-			# should corresponding snapshot's indexes be initialized automatically
-			auto-initialize = off
+  # Service URL for Pulsar cluster.
+  service-url = "pulsar://localhost:6650"
+  
+  # Time to wait before retrying an operation or reconnect.
+  retry-interval = 3s
+  
+  verity-certificate-authority = true
+  
+  # Verify certificate name with hostname.
+  verify-cerfiticate-name = false  
+  
+  # dispatcher used to drive snapshot storage actor
+  plugin-dispatcher = "akka.actor.default-dispatcher"
+}
 
-			# dispatcher used to drive snapshot storage actor
-			plugin-dispatcher = "akka.actor.default-dispatcher"
-	}
 akka.persistence.query.journal.pulsar {
   # Implementation class of the EventStore ReadJournalProvider
   class = "Akka.Persistence.Pulsar.Query.PuslarReadJournalProvider, Akka.Persistence.Pulsar"


### PR DESCRIPTION
1. Tests were failing at the initialization, because journal settings were not using correct HOCON configuration. 
2. Additionally snapshot store was using journal config path. I don't even know if having snapshot store based on even log system like pulsar has any sense.
3. Additionally, I added testkit support for snapshot store specification.